### PR TITLE
parse include tags for array of example snippets

### DIFF
--- a/lib/htmlincludes.js
+++ b/lib/htmlincludes.js
@@ -2,25 +2,26 @@ var tagRegex = /<include([^>\/]*)\s?\/?>/g;
 var attrRegex = /([a-z]+)=('([^']*)'|"([^"]*)"|([^\s]*))/g;
 
 function parseIncludeTags(docs, html, htmlAttribute) {
-    if(typeof html != 'string') {
-        return html;
-    }
-
     // find include tags
-    return html.replace(tagRegex, function(tag, tagAttrs) {
-        var attributes = {};
+    if (typeof html === 'string') {
+        html = [].concat([html]);
+    }
+    return html.map(function (snippet) {
+        return snippet.replace(tagRegex, function(tag, tagAttrs) {
+            var attributes = {};
 
-        // find attributes
-        var groups = tagAttrs.match(attrRegex);
-        for(var i = 0; i < groups.length; i++) {
-            var p = groups[i].split(/=/);
-            if(p[1]) {
-                attributes[p[0]] = p[1].replace(/^["']/, '').replace(/["']$/, '');
+            // find attributes
+            var groups = tagAttrs.match(attrRegex);
+            for(var i = 0; i < groups.length; i++) {
+                var p = groups[i].split(/=/);
+                if(p[1]) {
+                    attributes[p[0]] = p[1].replace(/^["']/, '').replace(/["']$/, '');
+                }
             }
-        }
 
-        // find the included document for these attributes
-        return findDocByAttributes(docs, attributes, htmlAttribute);
+            // find the included document for these attributes
+            return findDocByAttributes(docs, attributes, htmlAttribute);
+        });
     });
 }
 


### PR DESCRIPTION
Hey, this is a fix for those using multiple snippets with include tags in the Example YAML, like this
Example:
- <div>...<include title="test" section="test"></div>
- <div>...</div>
